### PR TITLE
Filter out new login monitoring policy

### DIFF
--- a/incident/settings.py
+++ b/incident/settings.py
@@ -13,6 +13,6 @@ DAYS_BACK = 1
 START_OF_DAY = 9
 END_OF_DAY = 17
 # if any of these are a susbtring of the service name, exclude it
-SERVICE_NAMES_TO_EXCLUDE = ['Out of hours', 'Remote access monitoring']
+SERVICE_NAMES_TO_EXCLUDE = ['Out of hours', 'Remote access monitoring', 'Fraud Auth Escalation Policy']
 # set to true to only report on high urgency incidents
 EXCLUDE_LOW_URGENCY = True


### PR DESCRIPTION
@ajvb this will keep what you set up at https://github.com/mozilla-services/cloudops-infra/blob/master/projects/pagerduty/tf/modules/fraud-auth-alerts/main.tf#L14 from showing up at https://sql.telemetry.mozilla.org/dashboard/monitoring-reports-incidents?p_days=8&p_days_undefined=8