### PR TITLE
Really filter out new login monitoring policy

### DIFF
--- a/incident/settings.py
+++ b/incident/settings.py
@@ -13,6 +13,6 @@ DAYS_BACK = 1
 START_OF_DAY = 9
 END_OF_DAY = 17
 # if any of these are a susbtring of the service name, exclude it
-SERVICE_NAMES_TO_EXCLUDE = ['Out of hours', 'Remote access monitoring', 'Fraud Auth Escalation Policy']
+SERVICE_NAMES_TO_EXCLUDE = ['Out of hours', 'Remote access monitoring', 'Fraud Auth Service']
 # set to true to only report on high urgency incidents
 EXCLUDE_LOW_URGENCY = True


### PR DESCRIPTION
Previous attempt at fix used the wrong name for the service.

You'd think I'd know to test things by now.